### PR TITLE
Added client cert copy and fixed CERT_PATH and ID

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -7,16 +7,31 @@ module VagrantPlugins
 
       def execute
         with_target_vms(nil, {:single_target=>true}) do |machine|
-          port = machine.provider.capability(:forwarded_ports).index(2376)
+          # Path to the private_key and where we will store the TLS Certificates
+          secrets_path = machine.data_dir
+
+          # First, get the TLS Certificates, if needed
+          if !File.directory?(File.expand_path(".docker", secrets_path)) then
+              # Finds the host machine port forwarded from guest sshd
+              hport = machine.provider.capability(:forwarded_ports).key(22)
+
+              # scp over the client side certs from guest to host machine
+              `scp -r -P #{hport} -o LogLevel=FATAL -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{secrets_path}/private_key vagrant@127.0.0.1:/home/vagrant/.docker #{secrets_path}`
+          end
+
+          # Print configuration information for accesing the docker daemon
+
+          # Finds the host machine port forwarded from guest docker
+           port = machine.provider.capability(:forwarded_ports).key(2376)
           message =
                 <<-eos
 Set the following environment variables to enable access to the
 docker daemon running inside of the vagrant virtual machine:
 
 export DOCKER_HOST=tcp://127.0.0.1:#{port}
-export DOCKER_CERT_PATH=PATH_NEEDED
+export DOCKER_CERT_PATH=#{secrets_path}/.docker
 export DOCKER_TLS_VERIFY=1
-export DOCKER_MACHINE_NAME=\"#{machine.id}\"
+export DOCKER_MACHINE_NAME=\"#{machine.index_uuidi[0..6]}\"
                 eos
           @env.ui.info(message)
         end

--- a/vagrant-adbinfo.gemspec
+++ b/vagrant-adbinfo.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'vagrant-adbinfo'
-  spec.version       = '0.0.1'
+  spec.version       = '0.0.2'
   spec.homepage      = 'https://github.com/bexelbie/vagrant-adbinfo'
   spec.summary       = 'Vagrant plugin that provides the IP address:port and tls certificate file location for a docker daemon'
 


### PR DESCRIPTION
o copies over client side certs with scp
o Eliminated scp warnings by:
  o added a /dev/null host identify file
  o turned loglevel to FATAL
o Sets DOCKER_CERT_PATH -  Fixes #2
o Updated .index to .key as .index is deprecated - Fixes #1
o Better comments and variables for paths
o Moved .docker to the data directory (where the cert is)
o Updated code with existance check for .docker
o Prints the correct (short) machine/box UUID
  o ID matches `vagrant global-status`
o Released as 0.0.2
