### PR TITLE
Find the IP address of the Guest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "centos7-cdk-test"
+  config.vm.box = "atomicapp/dev"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/lib/command.rb
+++ b/lib/command.rb
@@ -37,7 +37,14 @@ module VagrantPlugins
           hIP = machine.ssh_info[:host]
           hport = machine.ssh_info[:port]
           husername = machine.ssh_info[:username]
-	  guest_ip = "127.0.0.1"
+
+          # Find the guest IP
+          command = "ip route get 8.8.8.8 | awk 'NR==1 {print $NF}'"
+          guest_ip = ""
+          machine.communicate.execute(command) do |type, data|
+            guest_ip << data.chomp if type == :stdout
+          end
+	  
           # Finds the host machine port forwarded from guest docker
           port = machine.provider.capability(:forwarded_ports).key(2376)
           


### PR DESCRIPTION
Add functionality to determine and report the guest VM external IP

Vagrantfile - updated to use the CentOS7 box
lib/command.rb - modified to use machine.communicate.execute to find
guest IP
