### PR TITLE
Regenerate certs only for new ADB boxes and VirtualBox provider

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -51,6 +51,12 @@ module VagrantPlugins
           machine.communicate.execute(command) do |type, data|
             guest_ip << data.chomp if type == :stdout
           end
+
+	  # Regenerate the certs and restart docker daemon in case of the new ADB box and for VirtualBox provider
+	  if machine.provider_name == :virtualbox then
+	    command2 = "ls /opt/adb/cert-gen.sh && sudo rm /etc/docker/ca.pem && sudo systemctl restart docker"
+            machine.communicate.execute(command2)
+          end
 	  
           # Hard Code the Docker port because it is fixed on the VM
           # This also makes it easier for the plugin to be cross-provider


### PR DESCRIPTION
Fixes: #40 

```
 1. Identifies the provider for the machine
 2. Identifies if the box is latest
 3. The latest box has /opt/adb/cert-gen.sh script
 4. regenerates certs and restarts the docker daemon only if 1 and 2 are true
 5. Makes the plugin backward compatible with older ADB boxes
 6. In case of 5, the box neither regenerates the certs nor restart docker daemon
 7. With this patch, the certs for `docker` daemon are generated for correct IP assigned by provider
```
