### PR TITLE
Issue #67 Fix: OS is not a module

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -9,7 +9,7 @@ module OS
   end
 
   def OS.unix?
-    !OS.Windows?
+    !OS.windows?
   end
 
   def OS.linux?

--- a/lib/command.rb
+++ b/lib/command.rb
@@ -1,23 +1,4 @@
-module OS
-
-  def OS.windows?
-    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-  end
-
-  def OS.mac?
-    (/darwin/ =~ RUBY_PLATFORM) != nil
-  end
-
-  def OS.unix?
-    !OS.windows?
-  end
-
-  def OS.linux?
-    OS.unix? and not OS.mac?
-  end
-
-end
-
+require_relative 'os'
 module VagrantPlugins
   module DockerInfo
     class Command < Vagrant.plugin(2, :command)

--- a/lib/os.rb
+++ b/lib/os.rb
@@ -1,0 +1,18 @@
+# OS Module
+module OS
+  def self.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def self.mac?
+    (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def self.unix?
+    !windows?
+  end
+
+  def self.linux?
+    unix? && !mac?
+  end
+end


### PR DESCRIPTION
Fix for issue #67 .

Other changes:
- Using `self` instead of `OS`(Ruby style guide)
- Removed uncessary `self` inside method as:

```
def self.unix?
    !self.Windows?
end
# as self point to class/module itself so no need to mention self inside method above.
```
