### PR TITLE
Prep for Version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
+## v0.1.0 Jan 19, 2015
+
 - Fix#66: Added CHANGELOG.md to repository
 - Added gemspec in Gemfile to enable bundler packaging
 - Fix#67: OS is not a module (TypeError) on Windows
-- Update ADB box Atls namespace to projectatomic/adb
+- Update ADB box Atlas namespace to projectatomic/adb
 - Update README to reflect latest code and project goals
 - Update Vagrantfile for QuickStart guide
+
 
 ## v0.0.9 Nov 25, 2015
 
@@ -16,6 +19,5 @@
 
 - Fix#40: Handle private networking for different providers and generate Docker daemon TLS certs accordingly
 - Support backward compatibility with older versions of ADB boxes
-- lib/command.rb : Fixes bash file check command
+- lib/command.rb - Fixes bash file check command
 - Restart Docker daemon after generating correct TLS certs
-- 

--- a/vagrant-adbinfo.gemspec
+++ b/vagrant-adbinfo.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |spec|
   spec.name          = 'vagrant-adbinfo'
-  spec.version       = '0.0.9'
+  spec.version       = '0.1.0'
   spec.homepage      = 'https://github.com/bexelbie/vagrant-adbinfo'
-  spec.summary       = 'Vagrant plugin that provides the IP address:port and tls certificate file location for a docker daemon'
+  spec.summary       = 'Vagrant plugin that provides the IP address:port and TLS certificate file location for a docker daemon'
 
   spec.authors       = ['Brian Exelbierd', 'Navid Shaikh']
   spec.email         = ['bex@pobox.com', 'nshaikh@redhat.com']

--- a/vagrant-adbinfo.spec
+++ b/vagrant-adbinfo.spec
@@ -2,7 +2,7 @@
 %global vagrant_plugin_name vagrant-adbinfo
 
 Name: %{vagrant_plugin_name}
-Version: 0.0.9
+Version: 0.1.0
 Release: 1%{?dist}
 Summary: Vagrant plugin that provides the IP address:port and TLS certificate file location for a Docker daemon
 Group: Development/Languages
@@ -82,8 +82,18 @@ popd
 %{vagrant_plugin_instdir}/MAINTAINERS
 %{vagrant_plugin_instdir}/vagrant-adbinfo.gemspec
 %{vagrant_plugin_instdir}/vagrant-adbinfo.spec
+%{vagrant_plugin_instdir}/CHANGELOG.md
 
 %changelog
+* Tue Jan 19 2016 Navid Shaikh - 0.1.0-1
+- Bump version to 0.1.0
+- Fix#66: Added CHANGELOG.md to repository
+- Added gemspec in Gemfile to enable bundler packaging
+- Fix#67: OS is not a module (TypeError) on Windows
+- Update ADB box Atlas namespace to projectatomic/adb     
+- Update README to reflect latest code and project goals
+- Update Vagrantfile for QuickStart guide
+
 * Wed Nov 25 2015 Brian Exelbierd - 0.0.9-1
 - Fixes cert-generation script existence check, a bug was found where the cert
   was regenerated to often


### PR DESCRIPTION
- Updates vagrant-adbinfo.gemspec with version 0.1.0
- Updates vagrant-adbinfo.spec with version 0.1.0 and packages CHANGELOG.md
- Fixes typo in CHANGELOG.md
